### PR TITLE
[FEAT] UppalAdapter label processing

### DIFF
--- a/cosmic/adapter/templates/pytransitions_machine.mako
+++ b/cosmic/adapter/templates/pytransitions_machine.mako
@@ -16,7 +16,11 @@ class ${agent_name}(GraphMachine):
         )
         % endfor
 
-        states = ${states}
+        states = [
+            % for state in states:
+            ${state},
+            % endfor
+        ]
 
         transitions = [
             % for transition in transitions:
@@ -50,10 +54,7 @@ class ${agent_name}(GraphMachine):
         available_transitions = self.get_triggers(self.state)
         available_transitions = available_transitions[len(self.states):]
 
-        LOGGER.debug(f'Available transitions: {available_transitions}')
-
         for curr_transition in available_transitions:
             may_method_result = self.may_trigger(curr_transition)
             if may_method_result:
-                LOGGER.debug(f'Transition executed: {curr_transition}')
                 self.trigger(curr_transition)

--- a/cosmic/adapter/xml/adapter.py
+++ b/cosmic/adapter/xml/adapter.py
@@ -1,5 +1,6 @@
-from abc import abstractmethod, ABC
 import xml.etree.ElementTree as ET
+from abc import abstractmethod, ABC
+from typing import Dict, List
 
 
 class Adapter(ABC):
@@ -44,14 +45,20 @@ class Adapter(ABC):
 
     @staticmethod
     @abstractmethod
-    def filter_conditions(self, declaration: str) -> list:
-        """Filter the conditions from the declaration, returning a list of
-        function names.
-
+    def filter_conditions(self, label_text: str) -> Dict[str, List[str]]:
+        """Process the label text to find each of its declared conditions,
+        and unless (negative conditions), returning a dictionary with each of
+        them, in the following format:
+        ``` python
+        result_dict = {
+            "conditions": ["cond1", "cond2"],
+            "unless": ["cond3", "cond4"],
+        }
+        ```
         Args:
-            declaration (str): The declaration of the xml file.
+            label_text (str): The label text to be processed.
 
         Returns:
-            list: A list of function names.
+            dict: A dictionary containing the conditions and unless.
         """
         raise NotImplementedError()

--- a/cosmic/adapter/xml/adapter.py
+++ b/cosmic/adapter/xml/adapter.py
@@ -4,47 +4,54 @@ import xml.etree.ElementTree as ET
 
 class Adapter(ABC):
 
+    @staticmethod
     @abstractmethod
-    def parse_xml(self, arg_to_parse: str) -> ET.Element:
-        """function to get the root element from input file passed by argument
+    def find_xml_root(self, xml_file: str) -> ET.Element:
+        """Find the root of the xml file
 
         Args:
-            arg_to_parse (str)
+            xml_file (str): Path to the xml file.
 
         Returns:
-            ET.Element
+            ET.Element: The root of the xml file.
         """
         raise NotImplementedError()
 
+    @staticmethod
     @abstractmethod
-    def get_xml_data(self, root: ET.Element) -> dict:
-        """function to return states and transitions from xml
+    def get_xml_data(self, xml_file: str) -> dict:
+        """Extract the necessary data from the xml file, creating a dictionary
+        used to create state machines in the expected Cosmic framework format.
 
         Args:
-            root (ET.Element)
+            xml_file (str): Path to the xml file.
 
         Returns:
-            tuple[dict,dict]
+            dict: A dictionary containing the necessary data to create state
+                machines in the Cosmic framework format.
         """
         raise NotImplementedError()
 
+    @staticmethod
     @abstractmethod
     def print_dict(self, result_dict: dict) -> None:
-        """function to print dict
+        """Print the result dictionary in a human-readable format.
 
         Args:
-            result_dict (dict)
+            result_dict (dict): The result dictionary to be printed.
         """
         raise NotImplementedError()
 
+    @staticmethod
     @abstractmethod
     def filter_conditions(self, declaration: str) -> list:
-        """function to extract function names from xml
+        """Filter the conditions from the declaration, returning a list of
+        function names.
 
         Args:
-            declaration (str)
+            declaration (str): The declaration of the xml file.
 
         Returns:
-            list
+            list: A list of function names.
         """
         raise NotImplementedError()

--- a/cosmic/adapter/xml/uppaal_adapter.py
+++ b/cosmic/adapter/xml/uppaal_adapter.py
@@ -1,15 +1,38 @@
-from cosmic.adapter.xml.adapter import Adapter
 import xml.etree.ElementTree as ET
+from cosmic.adapter.xml.adapter import Adapter
 
 
 class UppaalAdapter(Adapter):
+    """Adapter for Uppaal xml files. This class is responsible for parsing
+    the xml file and extracting the necessary data into the general format
+    that the Cosmic framework uses.
+    """
 
-    def parse_xml(self, arg_to_parse: str) -> ET.Element:
-        tree = ET.parse(arg_to_parse)
+    @staticmethod
+    def find_xml_root(xml_file: str) -> ET.Element:
+        # documentations provided by the `Adapter` base class
+        tree = ET.parse(xml_file)
         root = tree.getroot()
         return root
 
-    def get_xml_data(self, root: ET.Element) -> dict:
+    @staticmethod
+    def filter_conditions(declaration: str) -> list:
+        # documentations provided by the `Adapter` base class
+        function_names = []
+
+        for line in declaration.splitlines():
+            line = line.strip()
+            if line.startswith("bool"):
+
+                name = line.split()[1].split("(")[0]
+                function_names.append(name)
+
+        return function_names
+
+    @staticmethod
+    def get_xml_data(xml_file: str) -> dict:
+        # documentations provided by the `Adapter` base class
+        root = UppaalAdapter.find_xml_root(xml_file)
         result = {}
 
         for template in root.findall(".//template"):
@@ -24,7 +47,9 @@ class UppaalAdapter(Adapter):
 
             for declaration in template.findall("declaration"):
                 condition = declaration.text
-                filtered_conditions = self.filter_conditions(condition)
+                filtered_conditions = UppaalAdapter.filter_conditions(
+                    condition,
+                )
 
             for location in template.findall("location"):
                 state_id = location.get("id")
@@ -51,20 +76,9 @@ class UppaalAdapter(Adapter):
 
         return result
 
-    def print_dict(self, result_dict: dict) -> None:
-        for agent, _ in result_dict.items():
+    @staticmethod
+    def print_dict(result_dict: dict) -> None:
+        # documentations provided by the `Adapter` base class
+        for agent, _agent_data in result_dict.items():
             print(f"agent: {agent}")
-            print(f"{_}\n")
-
-    def filter_conditions(self, declaration: str) -> list:
-
-        function_names = []
-
-        for line in declaration.splitlines():
-            line = line.strip()
-            if line.startswith("bool"):
-
-                name = line.split()[1].split("(")[0]
-                function_names.append(name)
-
-        return function_names
+            print(f"{_agent_data}\n")

--- a/cosmic/generator/code_generator.py
+++ b/cosmic/generator/code_generator.py
@@ -77,8 +77,7 @@ class CodeGenerator:
         if not xml_file.exists() or not xml_file.is_file():
             raise FileNotFoundError(f"File {xml_file} not found.")
 
-        root = self.xml_adapter.parse_xml(xml_file.resolve())
-        result_dict = self.xml_adapter.get_xml_data(root)
+        result_dict = self.xml_adapter.get_xml_data(xml_file.resolve())
 
         if not output_dir.exists():
             output_dir.mkdir()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,7 @@ target-version = ["py310", "py311", "py312"]
 include = '\.pyi?$'
 
 [tool.pytest.ini_options]
-addopts = "-vv --cov=src --cov-report=term-missing"
+addopts = "-vv --cov=cosmic --cov-report=term-missing"
 testpaths = [
     "tests",
 ]

--- a/tests/adapter/test_uppaal_adapter.py
+++ b/tests/adapter/test_uppaal_adapter.py
@@ -1,0 +1,186 @@
+import pytest
+import xml.etree.ElementTree as ET
+from cosmic.adapter.xml.uppaal_adapter import UppaalAdapter
+
+
+@pytest.fixture
+def transition_element() -> ET.Element:
+    transition = ET.Element('transition', id='id15')
+    ET.SubElement(transition, 'source', ref='1d6')
+    ET.SubElement(transition, 'target', ref='1d9')
+
+    guard_label = ET.SubElement(
+        transition,
+        "label",
+        kind="guard",
+        x="-1088",
+        y="-382",
+    )
+    guard_label.text = "!activated() && x == 0 || force_stop()"
+    sync_label = ET.SubElement(
+        transition,
+        "label",
+        kind="update",
+        x="-1071",
+        y="-348",
+    )
+    sync_label.text = "y = 0, in_op = false, reset_queue()"
+    ET.SubElement(transition, "nail", x="-790", y="-331")
+    return transition
+
+
+@pytest.fixture
+def simple_transition_element() -> ET.Element:
+    transition = ET.Element('transition', id='id15')
+    ET.SubElement(transition, 'source', ref='1d6')
+    ET.SubElement(transition, 'target', ref='1d9')
+    return transition
+
+
+def test_find_xml_root(xml_file):
+    root = UppaalAdapter.find_xml_root(xml_file)
+    assert root.tag == 'nta'
+
+
+@pytest.mark.parametrize(
+        'conditions, unless, expected',
+        [
+            (
+                [
+                    "place < buffer[rid].length",
+                    "time <= time_buffer",
+                ],
+                [],
+                {
+                    "conditions": ["place_eval", "time_eval"],
+                    "declared_functions": ["time_eval", "place_eval"],
+                },
+            ),
+            (
+                ["dependencies_met()", "is_valid()"],
+                ["halt_op()"],
+                {
+                    "conditions": ["dependencies_met", "is_valid"],
+                    "unless": ["halt_op"],
+                    "declared_functions": [
+                        "dependencies_met",
+                        "is_valid",
+                        "halt_op",
+                    ],
+                },
+            ),
+            (
+                ["dependencies_met()", "retry > 3"],
+                ["halt_op()"],
+                {
+                    "conditions": ["dependencies_met", "retry_eval"],
+                    "unless": ["halt_op"],
+                    "declared_functions": [
+                        "dependencies_met",
+                        "retry_eval",
+                        "halt_op",
+                    ],
+                }
+            ),
+            (
+                ["dependencies_met()", "retry > 3"],
+                ["time <= time_buffer"],
+                {
+                    "conditions": ["dependencies_met", "retry_eval"],
+                    "unless": ["time_eval"],
+                    "declared_functions": [
+                        "dependencies_met",
+                        "retry_eval",
+                        "time_eval",
+                    ],
+                }
+            )
+        ]
+)
+def test_declare_functions(conditions, unless, expected):
+    result = UppaalAdapter.declare_functions(conditions, unless)
+    assert result.keys() == expected.keys()
+    # bad test assertion, but dictionaries...
+    if expected.get('conditions'):
+        assert result['conditions'] == expected['conditions']
+    if expected.get('unless'):
+        assert result['unless'] == expected['unless']
+    if expected.get('declared_functions'):
+        for func in expected['declared_functions']:
+            assert func in result['declared_functions']
+
+
+@pytest.mark.parametrize(
+        'label_text, expected',
+        [
+            (
+                "place < buffer[rid].length && time <= time_buffer",
+                {
+                    "conditions": ["place_eval", "time_eval"],
+                    "declared_functions": ["time_eval", "place_eval"],
+                },
+            ),
+            (
+                "dependencies_met() && is_valid() || !halt_op()",
+                {
+                    "conditions": ["dependencies_met", "is_valid"],
+                    "unless": ["halt_op"],
+                    "declared_functions": [
+                        "dependencies_met",
+                        "is_valid",
+                        "halt_op",
+                    ],
+                },
+            ),
+            (
+                "dependencies_met() && retry > 3 || !halt_op()",
+                {
+                    "conditions": ["dependencies_met", "retry_eval"],
+                    "unless": ["halt_op"],
+                    "declared_functions": [
+                        "dependencies_met",
+                        "retry_eval",
+                        "halt_op",
+                    ],
+                }
+            )
+        ]
+)
+def test_filter_conditions(label_text, expected):
+    result = UppaalAdapter.filter_conditions(label_text)
+    assert result.keys() == expected.keys()
+    # bad test assertion, but dictionaries...
+    if expected.get('conditions'):
+        assert result['conditions'] == expected['conditions']
+    if expected.get('unless'):
+        assert result['unless'] == expected['unless']
+    if expected.get('declared_functions'):
+        for func in expected['declared_functions']:
+            assert func in result['declared_functions']
+
+
+def test_evalute_transition_without_labels(simple_transition_element):
+    has_label, content = UppaalAdapter.evaluate_transition(
+        simple_transition_element,
+    )
+    assert not has_label
+    assert content is None
+
+
+def test_evaluate_transition(transition_element):
+    has_label, content = UppaalAdapter.evaluate_transition(transition_element)
+    # bad test assertion, but dictionaries...
+    assert has_label
+    assert set(content.keys()) == {
+        'conditions', 'unless', 'after', 'declared_functions',
+    }
+    assert content['conditions'] == ['x_eval', 'force_stop']
+    assert content['unless'] == ['activated']
+    assert content['after'] == ['y_eval', 'in_op_eval', 'reset_queue']
+
+
+def test_get_xml_data(xml_file):
+    result_dict = UppaalAdapter.get_xml_data(xml_file)
+    expected_agents = {'RobotAssembler', 'HumanReceiver',
+                       'HumanValidator', 'Sector', 'RobotDeliver'}
+    assert set(result_dict.keys()) == expected_agents

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,14 @@
+import pytest
+from pathlib import Path
+
+
+@pytest.fixture
+def xml_file() -> Path:
+    """Fixture to return a valid xml file path.
+
+    Returns:
+        Path: The path to the xml file.
+    """
+    file_path = Path('tests\\mock_files\\hcl_teste.xml')
+    assert file_path.exists() and file_path.is_file()
+    return file_path

--- a/tests/generator/test_code_generator.py
+++ b/tests/generator/test_code_generator.py
@@ -1,6 +1,6 @@
 import pytest
 from pathlib import Path
-from src.generator.code_generator import CodeGenerator
+from cosmic.generator.code_generator import CodeGenerator
 from unittest.mock import MagicMock
 
 
@@ -43,15 +43,10 @@ def result_dict_mock():
 
 
 def test_get_template_file_returns_a_valid_file():
-    transitions_template = Path(
-        'src',
-        'adapter',
-        'templates',
-        'pytransitions_machine.mako',
-    )
-    assert CodeGenerator.get_template_file(
+    template_file = CodeGenerator.get_template_file(
         'pytransitions',
-    ) == transitions_template
+    )
+    assert template_file.exists() and template_file.is_file()
 
 
 def test_get_template_file_raises_not_implemented_error():


### PR DESCRIPTION
This pull request includes changes to the `cosmic/adapter/templates/pytransitions_machine.mako` file to improve the way states are defined and to clean up logging for transitions. 

Improvements to state definition:

* Modified the `states` attribute to be defined using a list comprehension instead of directly assigning the `states` variable. This change ensures that the states are dynamically generated and properly formatted.

Logging cleanup:

* Removed unimported debug logging statements for available transitions and executed transitions to streamline the code and reduce log clutter.