### PR TITLE
CHORE: generate wheel on release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,36 @@
+name: Publish Wheel on release
+
+on:
+  push:
+    tags:
+      - '*'
+
+jobs:
+  upload-release-asset:
+    name: Release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+
+      - name: Install Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install Poetry
+        run: pipx install poetry
+
+      - name: Install Dependencies
+        run: poetry install --all-groups
+
+      - name: Build Wheel
+        run: poetry build -f wheel
+
+      - name: Create Release with Github CLI
+        shell: bash
+        run: |
+          FILES_WHEEL=$(ls ./dist/*.whl)
+          gh release create ${{ github.ref }} $FILES_WHEEL --generate-notes
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -7,11 +7,6 @@ _Code Output for State Machine Interactive Creation_
     Code Output for State Machine Interactive Creation
   </h3>
 </div>
-<!-- <p align="center">
-  <a href="https://github.com/pantor/frankx/actions">
-    <img src="https://github.com/Curso-de-Robotica-e-IA/cosmic/workflows/CI/badge.svg" alt="CI">
-  </a>
-</p> -->
 
 `COSMIC` is a CLI tool capable to generate state machine code based on a XML representation of the state machine. The tool was initially designed to be used by the Residence in Robotics and AI at the UFPE's informatics center.
 
@@ -24,7 +19,13 @@ The idea behind COSMIC is to provide a tool capable of generating state machine 
 
 ## Installation
 
-The package is yet to be published on PyPI. For now, you can use poetry to install the package.
+You can install `COSMIC` using `pipx`
+
+At the repository, you can find the latest release of the package. Download the wheel file and install it using `pipx`:
+
+```bash
+pipx install <path_to_the_wheel_file>
+```
 
 ## Usage
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.black]
 line-length = 90
-target-version = ["py310", "py311", "py312"]
+target-version = ["py311", "py312"]
 include = '\.pyi?$'
 
 [tool.pytest.ini_options]


### PR DESCRIPTION
This pull request includes several changes to the repository, focusing on automating the release process, updating the installation instructions, and modifying the project configuration. Below are the most important changes:

### Automation and CI/CD:

* [`.github/workflows/release.yml`](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34R1-R36): Added a new GitHub Actions workflow to publish a wheel on release, including steps for checking out the repository, setting up Python, installing dependencies with Poetry, building the wheel, and creating a release with the GitHub CLI.

### Documentation:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L10-L14): Updated the installation instructions to guide users on installing `COSMIC` using `pipx` and removed outdated badge references. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L10-L14) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L27-R28)

### Project Configuration:

* [`pyproject.toml`](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L47-R47): Updated the `target-version` for the `black` tool to remove Python 3.10 support.